### PR TITLE
Allow HTTP read/connect timeouts to be configured for the Yoti Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,13 @@ Here is an example of how this works:
 ```java
 ActivityDetails activityDetails;
 try {
-	activityDetails = client.getActivityDetails(token);
-    if(activityDetails.getOutcome().isSuccessful()) {
-    	Optional<YourAppUserClass> user = yourUserSearchMethod(activityDetails.getUserId());
-    	if(user.isPresent()) {
-    		// handle login
-    	} else {
-    		// handle registration
-    	}
+    activityDetails = client.getActivityDetails(token);
+    Optional<YourAppUserClass> user = yourUserSearchMethod(activityDetails.getUserId());
+    if(user.isPresent()) {
+        // handle login
     } else {
-		// handle unhappy path
-	}            
+        // handle registration
+    }
 } catch (ProfileException e) {
     LOG.info("Could not get profile", e);
     return "error";
@@ -95,6 +91,17 @@ Where `yourUserSearchMethod` is a piece of logic in your app that is supposed to
 No matter if the user is a new or an existing one, Yoti will always provide her/his profile, so you don't necessarily need to store it.
 
 The `HumanProfile` class provides a set of methods to retrieve different user attributes. Whether the attributes are present or not depends on the settings you have applied to your app on Yoti Dashboard.
+
+## Connectivity Requirements
+
+Interacting with the `YotiClient` to get `ActivityDetails` is not an offline operation. Your application will need to be able to establish an outbound TCP connection to port 443 to the Yoti servers at `https://api.yoti.com` (by default - see the [Misc](#misc) section).
+
+By default the Yoti Client will block indefinitely when connecting to the remote server or reading data. Consequently it is **possible that your application thread could be blocked**. 
+
+Since version 1.1 of the `java-sdk-impl` you can set the following two system properties to control this behaviour:
+
+* `yoti.client.connect.timeout.ms` - the number of milliseconds that you are prepared to wait for the connection to be established. Zero is interpreted as an infinite timeout.
+* `yoti.client.read.timeout.ms` - the number of milliseconds that you are prepared to wait for data to become available to read in the response stream. Zero is interpreted as an infinite timeout.
 
 ## Modules
 The SDK is split into a number of modules for easier use and future extensibility. 

--- a/java-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/UrlConnector.java
+++ b/java-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/UrlConnector.java
@@ -5,21 +5,43 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 public class UrlConnector {
-    private final String urlString;
 
-    private UrlConnector(String urlString) {
+    private static final String DEFAULT_YOTI_CONNECT_TIMEOUT = "0";
+    private static final String DEFAULT_YOTI_READ_TIMEOUT = "0";
+    private static final String PROPERTY_YOTI_CONNECT_TIMEOUT = "yoti.client.connect.timeout.ms";
+    private static final String PROPERTY_YOTI_READ_TIMEOUT = "yoti.client.read.timeout.ms";
+
+    private final String urlString;
+    private final int connectTimeout;
+    private final int readTimeout;
+
+    private UrlConnector(final String urlString) {
         this.urlString = urlString;
+        this.connectTimeout = getPropertyOrDefaultAsInt(PROPERTY_YOTI_CONNECT_TIMEOUT, DEFAULT_YOTI_CONNECT_TIMEOUT);
+        this.readTimeout = getPropertyOrDefaultAsInt(PROPERTY_YOTI_READ_TIMEOUT, DEFAULT_YOTI_READ_TIMEOUT);
     }
 
-    public static UrlConnector get(String urlString) {
+    public static UrlConnector get(final String urlString) {
         return new UrlConnector(urlString);
     }
 
     public HttpURLConnection getHttpUrlConnection() throws IOException {
-        return (HttpURLConnection) new URL(urlString).openConnection();
+        final HttpURLConnection connection = (HttpURLConnection) new URL(urlString).openConnection();
+        configureTimeouts(connection);
+        return connection;
     }
 
     String getUrlString() {
         return urlString;
+    }
+
+    private void configureTimeouts(final HttpURLConnection connection) {
+        connection.setConnectTimeout(connectTimeout);
+        connection.setReadTimeout(readTimeout);
+    }
+
+    private int getPropertyOrDefaultAsInt(final String propertyKey, final String defaultValue) {
+        final String value = System.getProperty(propertyKey, defaultValue);
+        return Integer.parseInt(value);
     }
 }


### PR DESCRIPTION
For a client application calling the `getActivity` method of the `YotiClient` could be considered an unsafe/dangerous operation since you'd give up control of your application thread to our 3rd party code which internally has the potential to indefinitely block. This could cause thread pools on the client to all become blocked in a waiting state, eventually brining the client down (e.g. if all server worker threads are waiting). 

This change provides two system properties to allow the client HTTP connection timeout behaviour to be configured.

* `yoti.client.connect.timeout.ms` - the number of milliseconds that you are prepared to wait for the connection to be established. Zero is interpreted as an infinite timeout.
* `yoti.client.read.timeout.ms` - the number of milliseconds that you are prepared to wait for data to become available to read in the response stream. Zero is interpreted as an infinite timeout.

I have also updated the read me docs to reflect this change and removed a reference to the`activityDetails.getOutcome()` method since this appears to have been removed from the API.
