### PR TITLE
Update plugin & disable the .NET OWASP scanner

### DIFF
--- a/java-sdk-api/pom.xml
+++ b/java-sdk-api/pom.xml
@@ -8,7 +8,7 @@
   <name>Yoti Java SDK</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/java</url>
-  
+
   <developers>
     <developer>
       <name>Andras Bulla</name>
@@ -26,7 +26,7 @@
       <name>Quirino Zagarese</name>
     </developer>
   </developers>
-  
+
   <properties>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
@@ -83,10 +83,11 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>1.3.4</version>
+          <version>1.4.5</version>
           <configuration>
             <failBuildOnCVSS>${owasp.dependency.check.cvss.limit}</failBuildOnCVSS>
             <cveValidForHours>${owasp.dependency.check.cve.update.limit}</cveValidForHours>
+            <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
           </configuration>
         </plugin>
         <plugin>
@@ -267,10 +268,11 @@
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
-        <version>1.3.4</version>
+        <version>1.4.5</version>
         <configuration>
           <failBuildOnCVSS>${owasp.dependency.check.cvss.limit}</failBuildOnCVSS>
           <cveValidForHours>${owasp.dependency.check.cve.update.limit}</cveValidForHours>
+          <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
         </configuration>
         <reportSets>
           <reportSet>

--- a/java-sdk-impl/pom.xml
+++ b/java-sdk-impl/pom.xml
@@ -8,7 +8,7 @@
   <name>Yoti Java SDK implementation package</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/java</url>
-  
+
   <developers>
     <developer>
       <name>Andras Bulla</name>
@@ -26,7 +26,7 @@
       <name>Quirino Zagarese</name>
     </developer>
   </developers>
-  
+
   <properties>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
@@ -108,10 +108,11 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>1.3.4</version>
+          <version>1.4.5</version>
           <configuration>
             <failBuildOnCVSS>${owasp.dependency.check.cvss.limit}</failBuildOnCVSS>
             <cveValidForHours>${owasp.dependency.check.cve.update.limit}</cveValidForHours>
+            <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
           </configuration>
         </plugin>
         <plugin>
@@ -294,10 +295,11 @@
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
-        <version>1.3.4</version>
+        <version>1.4.5</version>
         <configuration>
           <failBuildOnCVSS>${owasp.dependency.check.cvss.limit}</failBuildOnCVSS>
           <cveValidForHours>${owasp.dependency.check.cve.update.limit}</cveValidForHours>
+          <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
         </configuration>
         <reportSets>
           <reportSet>

--- a/java-sdk-spring-boot-auto-config/pom.xml
+++ b/java-sdk-spring-boot-auto-config/pom.xml
@@ -92,10 +92,11 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>1.3.4</version>
+          <version>1.4.5</version>
           <configuration>
             <failBuildOnCVSS>${owasp.dependency.check.cvss.limit}</failBuildOnCVSS>
             <cveValidForHours>${owasp.dependency.check.cve.update.limit}</cveValidForHours>
+            <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
- Update plugin to [1.4.5](https://search.maven.org/#artifactdetails%7Corg.owasp%7Cdependency-check-maven%7C1.4.5%7Cmaven-plugin).
- Disable the .NET scanner since these modules don't use .NET packages and by default it is enabled. When building on non-windows systems that don't have Mono on the executable path this leads to (harmless) build warning appearing in the build log. E.g.

```
[WARNING] An error occurred with the .NET AssemblyAnalyzer;
this can be ignored unless you are scanning .NET DLLs. Please see the log for more details.
```

This warning was suppressed in [later versions ](https://github.com/jeremylong/DependencyCheck/issues/547) anyway, but best to disable features we don't need.