### PR TITLE
Dependency updates & house keeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ If you are using Maven, you need to add the following dependency:
 <dependency>
 	<groupId>com.yoti</groupId>
 	<artifactId>java-sdk-impl</artifactId>
-	<version>1.0</version>
+	<version>1.1</version>
 </dependency>
 ```
 If you are using Gradle, here is the dependency to add:
 
-`compile group: 'com.yoti', name: 'java-sdk-impl', version: '1.0'`
+`compile group: 'com.yoti', name: 'java-sdk-impl', version: '1.1'`
 
 
 ## Client initialisation

--- a/README.md
+++ b/README.md
@@ -132,6 +132,17 @@ No matter if the user is a new or an existing one, Yoti will always provide her/
 
 The `HumanProfile` class provides a set of methods to retrieve different user attributes. Whether the attributes are present or not depends on the settings you have applied to your app on Yoti Dashboard.
 
+## Connectivity Requirements
+
+Interacting with the `YotiClient` to get `ActivityDetails` is not an offline operation. Your application will need to be able to establish an outbound TCP connection to port 443 to the Yoti servers at `https://api.yoti.com` (by default - see the [Misc](#misc) section).
+
+By default the Yoti Client will block indefinitely when connecting to the remote server or reading data. Consequently it is **possible that your application thread could be blocked**. 
+
+Since version 1.1 of the `java-sdk-impl` you can set the following two system properties to control this behaviour:
+
+* `yoti.client.connect.timeout.ms` - the number of milliseconds that you are prepared to wait for the connection to be established. Zero is interpreted as an infinite timeout.
+* `yoti.client.read.timeout.ms` - the number of milliseconds that you are prepared to wait for data to become available to read in the response stream. Zero is interpreted as an infinite timeout.
+
 ## Modules
 
 The SDK is split into a number of modules for easier use and future extensibility. 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,17 @@ Everything you need to get started
 3) [Enabling the SDK](#enabling-the-sdk)-
 Description on importing your SDK 
 
-4) [Client initialisation](#client-initialisation)-
+4) [Client Initialisation](#client-initialisation)-
 Description on setting up your SDK
 
-5) [Profile retrieval](#profile-retrieval) -
+5) [Profile Retrieval](#profile-retrieval) -
 Description on setting up profile
 
-6) [Handling users](#handling-users) -
+6) [Handling Users](#handling-users) -
 Description on handling user log on's
+
+7) [Connectivity Requirements](#connectivity-requirements)-
+Description of network connectivity requirements
 
 7) [Modules](#modules)- 
 The Modules above explained

--- a/java-sdk-api/pom.xml
+++ b/java-sdk-api/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.yoti</groupId>
   <artifactId>java-sdk-api</artifactId>
-  <version>1.0</version>
+  <version>1.1</version>
   <name>Yoti Java SDK</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/java</url>
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.12</version>
+      <version>1.7.25</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.10.19</version>
+      <version>2.8.47</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -83,7 +83,7 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>1.4.5</version>
+          <version>2.1.0</version>
           <configuration>
             <failBuildOnCVSS>${owasp.dependency.check.cvss.limit}</failBuildOnCVSS>
             <cveValidForHours>${owasp.dependency.check.cve.update.limit}</cveValidForHours>
@@ -268,7 +268,7 @@
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
-        <version>1.4.5</version>
+        <version>2.1.0</version>
         <configuration>
           <failBuildOnCVSS>${owasp.dependency.check.cvss.limit}</failBuildOnCVSS>
           <cveValidForHours>${owasp.dependency.check.cve.update.limit}</cveValidForHours>

--- a/java-sdk-dummy/pom.xml
+++ b/java-sdk-dummy/pom.xml
@@ -8,7 +8,7 @@
   <name>Yoti Java SDK mock testing package</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/java</url>
-  
+
   <developers>
     <developer>
       <name>Andras Bulla</name>
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>java-sdk-api</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
     </dependency>
   </dependencies>
 

--- a/java-sdk-impl/pom.xml
+++ b/java-sdk-impl/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.yoti</groupId>
   <artifactId>java-sdk-impl</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.1</version>
   <name>Yoti Java SDK implementation package</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/java</url>
@@ -61,12 +61,12 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.51</version>
+      <version>1.57</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.7.5</version>
+      <version>2.7.9.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
@@ -76,12 +76,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.12</version>
+      <version>1.7.25</version>
     </dependency>
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>java-sdk-api</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
     </dependency>
     <!-- Testing dependencies -->
     <dependency>
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.10.19</version>
+      <version>2.8.47</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -108,7 +108,7 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>1.4.5</version>
+          <version>2.1.0</version>
           <configuration>
             <failBuildOnCVSS>${owasp.dependency.check.cvss.limit}</failBuildOnCVSS>
             <cveValidForHours>${owasp.dependency.check.cve.update.limit}</cveValidForHours>
@@ -295,7 +295,7 @@
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
-        <version>1.4.5</version>
+        <version>2.1.0</version>
         <configuration>
           <failBuildOnCVSS>${owasp.dependency.check.cvss.limit}</failBuildOnCVSS>
           <cveValidForHours>${owasp.dependency.check.cve.update.limit}</cveValidForHours>

--- a/java-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/UrlConnector.java
+++ b/java-sdk-impl/src/main/java/com/yoti/api/client/spi/remote/call/UrlConnector.java
@@ -5,21 +5,43 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 public class UrlConnector {
-    private final String urlString;
 
-    private UrlConnector(String urlString) {
+    private static final String DEFAULT_YOTI_CONNECT_TIMEOUT = "0";
+    private static final String DEFAULT_YOTI_READ_TIMEOUT = "0";
+    private static final String PROPERTY_YOTI_CONNECT_TIMEOUT = "yoti.client.connect.timeout.ms";
+    private static final String PROPERTY_YOTI_READ_TIMEOUT = "yoti.client.read.timeout.ms";
+
+    private final String urlString;
+    private final int connectTimeout;
+    private final int readTimeout;
+
+    private UrlConnector(final String urlString) {
         this.urlString = urlString;
+        this.connectTimeout = getPropertyOrDefaultAsInt(PROPERTY_YOTI_CONNECT_TIMEOUT, DEFAULT_YOTI_CONNECT_TIMEOUT);
+        this.readTimeout = getPropertyOrDefaultAsInt(PROPERTY_YOTI_READ_TIMEOUT, DEFAULT_YOTI_READ_TIMEOUT);
     }
 
-    public static UrlConnector get(String urlString) {
+    public static UrlConnector get(final String urlString) {
         return new UrlConnector(urlString);
     }
 
     public HttpURLConnection getHttpUrlConnection() throws IOException {
-        return (HttpURLConnection) new URL(urlString).openConnection();
+        final HttpURLConnection connection = (HttpURLConnection) new URL(urlString).openConnection();
+        configureTimeouts(connection);
+        return connection;
     }
 
     String getUrlString() {
         return urlString;
+    }
+
+    private void configureTimeouts(final HttpURLConnection connection) {
+        connection.setConnectTimeout(connectTimeout);
+        connection.setReadTimeout(readTimeout);
+    }
+
+    private int getPropertyOrDefaultAsInt(final String propertyKey, final String defaultValue) {
+        final String value = System.getProperty(propertyKey, defaultValue);
+        return Integer.parseInt(value);
     }
 }

--- a/java-sdk-spring-boot-auto-config/README.md
+++ b/java-sdk-spring-boot-auto-config/README.md
@@ -2,9 +2,6 @@
 
 This module aims to make integration of the Yoti Java SDK client into Spring Boot projects more simple by reducing the
  amount of boilerplate code required by the client application and allows the developer to simply provide two properties.
- 
-You will still need to provide an appropriate implementation of the Yoti Java SDK as one is not included in this module. 
-See the example dependencies below for more information on how to do this.
 
 ## Requirements
 
@@ -21,12 +18,7 @@ If you are using Maven, you need to add the following dependencies:
 <dependency>
   <groupId>com.yoti</groupId>
   <artifactId>java-sdk-spring-boot-auto-config</artifactId>
-  <version>1.0</version>
-</dependency>
-<dependency>
-  <groupId>com.yoti</groupId>
-  <artifactId>java-sdk-impl</artifactId>
-  <version>1.0</version>
+  <version>1.1</version>
 </dependency>
 ```
 
@@ -34,8 +26,7 @@ If you are using Maven, you need to add the following dependencies:
 If you are using Gradle, here is the dependency to add:
 
 ```
-compile group: 'com.yoti', name: 'java-sdk-spring-boot-auto-config', version: '1.0'
-compile group: 'com.yoti', name: 'java-sdk-impl', version: '1.0'
+compile group: 'com.yoti', name: 'java-sdk-spring-boot-auto-config', version: '1.1'
 ```
 
 

--- a/java-sdk-spring-boot-auto-config/pom.xml
+++ b/java-sdk-spring-boot-auto-config/pom.xml
@@ -38,7 +38,6 @@
     <url>http://github.com/getyoti/java.git</url>
   </scm>
 
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -61,13 +60,11 @@
       <groupId>com.yoti</groupId>
       <artifactId>java-sdk-api</artifactId>
       <version>1.1</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>java-sdk-impl</artifactId>
       <version>1.1</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/java-sdk-spring-boot-auto-config/pom.xml
+++ b/java-sdk-spring-boot-auto-config/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>com.yoti</groupId>
   <artifactId>java-sdk-spring-boot-auto-config</artifactId>
-  <version>1.0</version>
+  <version>1.1</version>
   <name>Yoti Java Spring Boot Integration</name>
   <description>Library to integrate the Java Yoti SDK with Spring Boot Applications</description>
   <url>https://github.com/getyoti/java</url>
@@ -53,20 +53,20 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
-      <version>1.5.2.RELEASE</version>
+      <version>1.5.6.RELEASE</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>java-sdk-api</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>java-sdk-impl</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
       <scope>provided</scope>
     </dependency>
 
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.10.19</version>
+      <version>2.8.47</version>
       <scope>test</scope>
     </dependency>
 
@@ -92,7 +92,7 @@
         <plugin>
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
-          <version>1.4.5</version>
+          <version>2.1.0</version>
           <configuration>
             <failBuildOnCVSS>${owasp.dependency.check.cvss.limit}</failBuildOnCVSS>
             <cveValidForHours>${owasp.dependency.check.cve.update.limit}</cveValidForHours>

--- a/java-sdk-spring-boot-auto-config/src/test/java/com/yoti/api/spring/SpringResourceKeyPairSourceTest.java
+++ b/java-sdk-spring-boot-auto-config/src/test/java/com/yoti/api/spring/SpringResourceKeyPairSourceTest.java
@@ -4,7 +4,7 @@ import com.yoti.api.client.KeyPairSource;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 
 import java.io.IOException;
@@ -18,8 +18,6 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class SpringResourceKeyPairSourceTest {
 
-    private static final int DUMMY_BYTE = 4;
-
     private final KeyPair dummyKeyPair = new KeyPair(null, null);
 
     @Mock
@@ -32,7 +30,6 @@ public class SpringResourceKeyPairSourceTest {
     public void testGetFromStream() throws Exception {
 
         when(mockResource.getInputStream()).thenReturn(mockStream);
-        when(mockStream.read()).thenReturn(DUMMY_BYTE);
 
         final SpringResourceKeyPairSource source = new SpringResourceKeyPairSource(mockResource);
         final KeyPair keyPair = source.getFromStream(new TestStreamVisitor());
@@ -46,6 +43,7 @@ public class SpringResourceKeyPairSourceTest {
 
         @Override
         public KeyPair accept(final InputStream in) throws IOException {
+            assertThat(in, sameInstance(mockStream));
             return dummyKeyPair;
         }
 

--- a/java-sdk-springboot-example/pom.xml
+++ b/java-sdk-springboot-example/pom.xml
@@ -36,11 +36,6 @@
       <version>1.1</version>
     </dependency>
     <dependency>
-      <groupId>com.yoti</groupId>
-      <artifactId>java-sdk-impl</artifactId>
-      <version>1.1</version>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
     </dependency>

--- a/java-sdk-springboot-example/pom.xml
+++ b/java-sdk-springboot-example/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.5.2.RELEASE</version>
+    <version>1.5.6.RELEASE</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <properties>
@@ -33,12 +33,12 @@
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>java-sdk-spring-boot-auto-config</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
     </dependency>
     <dependency>
       <groupId>com.yoti</groupId>
       <artifactId>java-sdk-impl</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <name>Yoti Java SDK</name>
   <description>Java SDK for simple integration with the Yoti platform</description>
   <url>https://github.com/getyoti/java</url>
-  
+
   <developers>
     <developer>
       <name>Andras Bulla</name>
@@ -26,11 +26,12 @@
       <name>Quirino Zagarese</name>
     </developer>
   </developers>
-  
+
   <modules>
     <module>java-sdk-api</module>
     <module>java-sdk-dummy</module>
     <module>java-sdk-impl</module>
+    <module>java-sdk-spring-boot-auto-config</module>
     <module>java-sdk-springboot-example</module>
   </modules>
   <build>


### PR DESCRIPTION
# Background
Thought we should do some house keeping to stay up to date with newer libs where we can that may contain security/bug fixes.

Some of these are passed on as transitive dependencies to clients that depend on us too (e.g. SLF4J), so our users will be happier if they can use later/latest versions with more confidence too.

## Internal POM Version Numbers
* Incremented POM versions for new releases and updated dependencies to later versions (where possible). e.g. 1.1 release ready for maven central if/when this is merged and tested.

## Third Party Dependencies
* BouncyCastle 1.51 -> 1.57 which include bug & security fixes: https://www.bouncycastle.org/releasenotes.html
* SLF4J 1.7.12 -> 1.7.25
* Mockito 1.10.19 -> 2.8.47
* OWASP Plugin 1.4.5 -> 2.1.0a
* Jackson databinding 2.7.5 -> 2.7.9.1 (there are actually later versions in the 2.8.x and 2.9.x series but there are not JDK 6 compatible and *AFAIK the SDK is intended to be JDK 6 compatible* to ensure enterprises who cannot update to later versions can still use the API).
* Protobuf libs can be updated to 3 series but I am not sure about binary compatibility between 2/3 so I'm not sure it's safe to do this (so I haven't).
* Updated Spring Boot to latest version 1.5.2.RELEASE -> 1.5.6.RELEASE

## Security Analysis
I have noticed that the OWASP dependency plugin does trigger build failures for vulnerable dependencies. This question that I asked on the spring github issues list seems to be clear that these are false positives: https://github.com/spring-projects/spring-boot/issues/9997.

You can skip these checks in the build with the `dependency-check.skip` user property, e.g. 
```
mvn clean install -Ddependency-check.skip=true
```

I have left the plugin in, however, as I still feel it's useful to see the list if you want to - rather than removing it altogether. This way, although the build doesn't fail automatically, we can still proactively be more aware of the "vulnerabilities" and decide if we are happy or not (e.g. false positives or not relevant).

## Test Code Change
* Made a small change to a test based on updated Mockito version (deprecated classes and pointed out an error in the test itself).