### PR TITLE
SDK-2825: Add support for setting company_profile when creating an IDV session

### DIFF
--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/CompanyProfilePayload.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/CompanyProfilePayload.java
@@ -1,0 +1,45 @@
+package com.yoti.api.client.docs.session.create;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CompanyProfilePayload {
+
+    @JsonProperty("company_name")
+    private final String companyName;
+
+    private CompanyProfilePayload(String companyName) {
+        this.companyName = companyName;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public static class Builder {
+
+        private String companyName;
+
+        Builder() {}
+
+        /**
+         * Sets the company name to be used for the session
+         *
+         * @param companyName the company name
+         * @return the builder
+         */
+        public Builder withCompanyName(String companyName) {
+            this.companyName = companyName;
+            return this;
+        }
+
+        public CompanyProfilePayload build() {
+            return new CompanyProfilePayload(companyName);
+        }
+
+    }
+
+}

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/SessionSpec.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/docs/session/create/SessionSpec.java
@@ -69,6 +69,9 @@ public class SessionSpec {
     @JsonProperty("create_identity_profile_preview")
     private final Boolean createIdentityProfilePreview;
 
+    @JsonProperty("company_profile")
+    private final CompanyProfilePayload companyProfile;
+
     private SessionSpec(Integer clientSessionTokenTtl,
             Integer resourcesTtl,
             ImportTokenPayload importToken,
@@ -85,7 +88,8 @@ public class SessionSpec {
             SubjectPayload subject,
             ResourceCreationContainer resources,
             Boolean createIdentityProfilePreview,
-            AdvancedIdentityProfileRequirementsPayload advancedIdentityProfileRequirements) {
+            AdvancedIdentityProfileRequirementsPayload advancedIdentityProfileRequirements,
+            CompanyProfilePayload companyProfile) {
         this.clientSessionTokenTtl = clientSessionTokenTtl;
         this.resourcesTtl = resourcesTtl;
         this.importToken = importToken;
@@ -103,6 +107,7 @@ public class SessionSpec {
         this.resources = resources;
         this.createIdentityProfilePreview = createIdentityProfilePreview;
         this.advancedIdentityProfileRequirements = advancedIdentityProfileRequirements;
+        this.companyProfile = companyProfile;
     }
 
     public static Builder builder() {
@@ -263,6 +268,15 @@ public class SessionSpec {
         return advancedIdentityProfileRequirements;
     }
 
+    /**
+     * The company profile to be used for the session
+     *
+     * @return the company profile
+     */
+    public CompanyProfilePayload getCompanyProfile() {
+        return companyProfile;
+    }
+
     public static class Builder {
 
         private final List<RequestedCheck<?>> requestedChecks;
@@ -282,6 +296,7 @@ public class SessionSpec {
         private SubjectPayload subject;
         private ResourceCreationContainer resources;
         private Boolean createIdentityProfilePreview;
+        private CompanyProfilePayload companyProfile;
 
         private Builder() {
             requestedChecks = new ArrayList<>();
@@ -478,6 +493,17 @@ public class SessionSpec {
         }
 
         /**
+         * Sets the company profile to be used for the session
+         *
+         * @param companyProfile the company profile
+         * @return the builder
+         */
+        public Builder withCompanyProfile(CompanyProfilePayload companyProfile) {
+            this.companyProfile = companyProfile;
+            return this;
+        }
+
+        /**
          * Builds the {@link SessionSpec} based on the values supplied to the builder
          *
          * @return the built {@link SessionSpec}
@@ -500,7 +526,8 @@ public class SessionSpec {
                     subject,
                     resources,
                     createIdentityProfilePreview,
-                    advancedIdentityProfileRequirementsPayload);
+                    advancedIdentityProfileRequirementsPayload,
+                    companyProfile);
         }
     }
 

--- a/yoti-sdk-api/src/test/java/com/yoti/api/client/docs/session/create/CompanyProfilePayloadTest.java
+++ b/yoti-sdk-api/src/test/java/com/yoti/api/client/docs/session/create/CompanyProfilePayloadTest.java
@@ -1,0 +1,30 @@
+package com.yoti.api.client.docs.session.create;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.Test;
+
+public class CompanyProfilePayloadTest {
+
+    private static final String SOME_COMPANY_NAME = "someCompanyName";
+
+    @Test
+    public void shouldBuildWithCompanyName() {
+        CompanyProfilePayload result = CompanyProfilePayload.builder()
+                .withCompanyName(SOME_COMPANY_NAME)
+                .build();
+
+        assertThat(result.getCompanyName(), is(SOME_COMPANY_NAME));
+    }
+
+    @Test
+    public void companyName_shouldBeNullWhenNotSet() {
+        CompanyProfilePayload result = CompanyProfilePayload.builder()
+                .build();
+
+        assertThat(result.getCompanyName(), is(nullValue()));
+    }
+
+}

--- a/yoti-sdk-api/src/test/java/com/yoti/api/client/docs/session/create/SessionSpecTest.java
+++ b/yoti-sdk-api/src/test/java/com/yoti/api/client/docs/session/create/SessionSpecTest.java
@@ -50,6 +50,7 @@ public class SessionSpecTest {
     @Mock ImportTokenPayload importTokenMock;
     @Mock IdentityProfileRequirementsPayload identityProfileRequirementsPayloadMock;
     @Mock SubjectPayload subjectPayloadMock;
+    @Mock CompanyProfilePayload companyProfilePayloadMock;
 
     @Test
     public void shouldBuildWithMinimalConfiguration() {
@@ -72,6 +73,7 @@ public class SessionSpecTest {
         assertThat(result.getSubject(), is(nullValue()));
         assertThat(result.getResources(), is(nullValue()));
         assertThat(result.getCreateIdentityProfilePreview(), is(nullValue()));
+        assertThat(result.getCompanyProfile(), is(nullValue()));
     }
 
     @Test
@@ -250,6 +252,15 @@ public class SessionSpecTest {
                 .build();
 
         assertThat(sessionSpec.getImportToken(), is(importTokenMock));
+    }
+
+    @Test
+    public void withCompanyProfile_shouldSetTheCompanyProfile() {
+        SessionSpec result = SessionSpec.builder()
+                .withCompanyProfile(companyProfilePayloadMock)
+                .build();
+
+        assertThat(result.getCompanyProfile(), is(companyProfilePayloadMock));
     }
 
 }


### PR DESCRIPTION
## Summary

Adds support for the new `company_profile` object in the create-session payload, letting a Relying Business set `company_name` for the session (used on generated PDFs etc.).

```json
{
  "company_profile": {
    "company_name": "Acme Ltd"
  }
}
```