### PR TITLE
SDK-2800: Deprecate discontinued AML check API

### DIFF
--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/AmlException.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/AmlException.java
@@ -2,7 +2,11 @@ package com.yoti.api.client;
 
 /**
  * Signals that a problem occurred while performing an AML check
+ *
+ * @deprecated The AML check service has been discontinued and this class is no longer used.
+ *             This API will be removed in the next major release.
  */
+@Deprecated
 public class AmlException extends Exception {
 
     private static final long serialVersionUID = 3210133542178934016L;

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/YotiClient.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/YotiClient.java
@@ -93,7 +93,11 @@ public class YotiClient {
      *
      * @throws AmlException
      *             aggregate exception signalling issues during the call
+     *
+     * @deprecated The AML check service has been discontinued and this call will no longer succeed.
+     *             This API will be removed in the next major release.
      */
+    @Deprecated
     public AmlResult performAmlCheck(AmlProfile amlProfile) throws AmlException {
         LOG.debug("Performing aml check...");
         return remoteAmlService.performCheck(amlProfile);

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlAddress.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlAddress.java
@@ -2,6 +2,11 @@ package com.yoti.api.client.aml;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * @deprecated The AML check service has been discontinued and this class is no longer used.
+ *             This API will be removed in the next major release.
+ */
+@Deprecated
 public class AmlAddress {
 
     @JsonProperty("post_code")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlProfile.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlProfile.java
@@ -2,6 +2,11 @@ package com.yoti.api.client.aml;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * @deprecated The AML check service has been discontinued and this class is no longer used.
+ *             This API will be removed in the next major release.
+ */
+@Deprecated
 public class AmlProfile {
 
     @JsonProperty("given_names")

--- a/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlResult.java
+++ b/yoti-sdk-api/src/main/java/com/yoti/api/client/aml/AmlResult.java
@@ -4,7 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * The results of the aml check.
+ *
+ * @deprecated The AML check service has been discontinued and this class is no longer used.
+ *             This API will be removed in the next major release.
  */
+@Deprecated
 public class AmlResult {
 
     @JsonProperty("on_fraud_list")


### PR DESCRIPTION
Deprecates the AML check API (`YotiClient#performAmlCheck`, `AmlProfile`, `AmlAddress`, `AmlResult`, `AmlException`) since the underlying service has been discontinued. Removal is planned for the next major release.